### PR TITLE
feat: add an API to drop specific table

### DIFF
--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -135,7 +135,7 @@ export class Database<S = any> {
   }
 
   async drop<T extends Keys<S>>(table: T) {
-    this.getDriver(table).drop(table)
+    await this.getDriver(table).drop(table)
   }
 
   async dropAll() {
@@ -160,8 +160,7 @@ export namespace Driver {
 export abstract class Driver {
   abstract start(): Promise<void>
   abstract stop(): Promise<void>
-  abstract drop(table: string): Promise<void>
-  abstract drop(): Promise<void>
+  abstract drop(table?: string): Promise<void>
   abstract stats(): Promise<Partial<Driver.Stats>>
   abstract prepare(name: string): Promise<void>
   abstract get(sel: Selection.Immutable, modifier: Modifier): Promise<any>

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -135,7 +135,6 @@ export class Database<S = any> {
   }
 
   async drop<T extends Keys<S>>(table: T) {
-    await this.tasks[table]
     this.getDriver(table).drop(table)
   }
 
@@ -162,7 +161,7 @@ export abstract class Driver {
   abstract start(): Promise<void>
   abstract stop(): Promise<void>
   abstract drop(table: string): Promise<void>
-  abstract dropAll(): Promise<void>
+  abstract drop(): Promise<void>
   abstract stats(): Promise<Partial<Driver.Stats>>
   abstract prepare(name: string): Promise<void>
   abstract get(sel: Selection.Immutable, modifier: Modifier): Promise<any>

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -139,7 +139,7 @@ export class Database<S = any> {
   }
 
   async dropAll() {
-    await Promise.all(Object.values(this.drivers).map(driver => driver.dropAll()))
+    await Promise.all(Object.values(this.drivers).map(driver => driver.drop()))
   }
 
   async stats() {

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -134,8 +134,13 @@ export class Database<S = any> {
     await Promise.all(drivers.map(driver => driver.stop()))
   }
 
+  async drop<T extends Keys<S>>(table: T) {
+    await this.tasks[table]
+    this.getDriver(table).drop(table)
+  }
+
   async dropAll() {
-    await Promise.all(Object.values(this.drivers).map(driver => driver.drop()))
+    await Promise.all(Object.values(this.drivers).map(driver => driver.dropAll()))
   }
 
   async stats() {
@@ -156,7 +161,8 @@ export namespace Driver {
 export abstract class Driver {
   abstract start(): Promise<void>
   abstract stop(): Promise<void>
-  abstract drop(): Promise<void>
+  abstract drop(table: string): Promise<void>
+  abstract dropAll(): Promise<void>
   abstract stats(): Promise<Partial<Driver.Stats>>
   abstract prepare(name: string): Promise<void>
   abstract get(sel: Selection.Immutable, modifier: Modifier): Promise<any>

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -74,6 +74,10 @@ class MemoryDriver extends Driver {
     }).filter(Boolean)
   }
 
+  async drop(table: string) {
+    delete this.#store[table]
+  }
+
   async drop() {
     this.#store = {}
     // await this.#loader?.drop()

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -74,13 +74,12 @@ class MemoryDriver extends Driver {
     }).filter(Boolean)
   }
 
-  async drop(table: string) {
-    delete this.#store[table]
-  }
-
-  async drop() {
-    this.#store = {}
-    // await this.#loader?.drop()
+  async drop(table?: string) {
+    if (table) {
+      delete this.#store[table]
+    } else {
+      this.#store = { _fields: [] }
+    }
   }
 
   async stats() {

--- a/packages/mongo/src/index.ts
+++ b/packages/mongo/src/index.ts
@@ -178,6 +178,10 @@ class MongoDriver extends Driver {
     ])
   }
 
+  async drop(table: string) {
+    await this.db.dropCollection(table)
+  }
+
   async drop() {
     await Promise.all([
       '_fields',

--- a/packages/mongo/src/index.ts
+++ b/packages/mongo/src/index.ts
@@ -1,5 +1,5 @@
 import { Collection, Db, IndexDescription, MongoClient, MongoError } from 'mongodb'
-import { Dict, isNullable, makeArray, noop, omit, pick } from 'cosmokit'
+import { Dict, makeArray, noop, omit, pick } from 'cosmokit'
 import { Database, Driver, Eval, executeEval, executeUpdate, Query, RuntimeError, Selection } from '@minatojs/core'
 import { URLSearchParams } from 'url'
 import { Transformer } from './utils'
@@ -178,11 +178,11 @@ class MongoDriver extends Driver {
     ])
   }
 
-  async drop(table: string) {
-    await this.db.dropCollection(table)
-  }
-
-  async drop() {
+  async drop(table?: string) {
+    if (table) {
+      await this.db.dropCollection(table)
+      return
+    }
     await Promise.all([
       '_fields',
       ...Object.keys(this.database.tables),

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -326,6 +326,10 @@ class MySQLDriver extends Driver {
     return this.queue(sql, values)
   }
 
+  async drop(table: string) {
+    this.query(`DROP TABLE ${escapeId(table)}`)
+  }
+
   async drop() {
     const data = await this._select('information_schema.tables', ['TABLE_NAME'], 'TABLE_SCHEMA = ?', [this.config.database])
     if (!data.length) return

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -326,11 +326,8 @@ class MySQLDriver extends Driver {
     return this.queue(sql, values)
   }
 
-  async drop(table: string) {
-    this.query(`DROP TABLE ${escapeId(table)}`)
-  }
-
-  async drop() {
+  async drop(table?: string) {
+    if (table) return this.query(`DROP TABLE ${escapeId(table)}`)
     const data = await this._select('information_schema.tables', ['TABLE_NAME'], 'TABLE_SCHEMA = ?', [this.config.database])
     if (!data.length) return
     await this.query(data.map(({ TABLE_NAME }) => `DROP TABLE ${escapeId(TABLE_NAME)}`).join('; '))

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -241,7 +241,12 @@ class SQLiteDriver extends Driver {
     return result
   }
 
-  async drop() {
+  async drop(table: string) {
+    const droppedTable = this.database.tables[table]
+    this.#run(`DROP TABLE ${escapeId(droppedTable)}`)
+  }
+
+  async dropAll() {
     const tables = Object.keys(this.database.tables)
     for (const table of tables) {
       this.#run(`DROP TABLE ${escapeId(table)}`)

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -242,11 +242,10 @@ class SQLiteDriver extends Driver {
   }
 
   async drop(table: string) {
-    const droppedTable = this.database.tables[table]
-    this.#run(`DROP TABLE ${escapeId(droppedTable)}`)
+    this.#run(`DROP TABLE ${escapeId(table)}`)
   }
 
-  async dropAll() {
+  async drop() {
     const tables = Object.keys(this.database.tables)
     for (const table of tables) {
       this.#run(`DROP TABLE ${escapeId(table)}`)

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -241,11 +241,8 @@ class SQLiteDriver extends Driver {
     return result
   }
 
-  async drop(table: string) {
-    this.#run(`DROP TABLE ${escapeId(table)}`)
-  }
-
-  async drop() {
+  async drop(table?: string) {
+    if (table) return this.#run(`DROP TABLE ${escapeId(table)}`)
     const tables = Object.keys(this.database.tables)
     for (const table of tables) {
       this.#run(`DROP TABLE ${escapeId(table)}`)


### PR DESCRIPTION
## descrpition of this pull request
Add an API to drop specific table.

## the issue of this pull request aim to solve
This pull request aims to solve the problem of not being able to delete specific tables. Currently, minato only has an API for deleting all tables. this pull request adds the ability to delete specific tables.

<!-- ## other information
This pull request is still in progress and support for various databases is still being added. -->
