### PR TITLE
部分实现`$random` (#20)

### DIFF
--- a/packages/core/src/eval.ts
+++ b/packages/core/src/eval.ts
@@ -89,6 +89,9 @@ export namespace Eval {
     max(value: Number): Expr<number>
     min(value: Number): Expr<number>
     count(value: Any): Expr<number>
+
+    // random
+    random(value?: never): Expr<number>
   }
 }
 
@@ -166,6 +169,9 @@ Eval.avg = unary('avg', (expr, table) => table.reduce((prev, curr) => prev + exe
 Eval.max = unary('max', (expr, table) => Math.max(...table.map(data => executeAggr(expr, data))))
 Eval.min = unary('min', (expr, table) => Math.min(...table.map(data => executeAggr(expr, data))))
 Eval.count = unary('count', (expr, table) => new Set(table.map(data => executeAggr(expr, data))).size)
+
+// random
+Eval.random = unary('random', (expr, table) => Math.random())
 
 export { Eval as $ }
 

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -2,7 +2,7 @@ import { createPool, format } from '@vlasky/mysql'
 import type { OkPacket, Pool, PoolConfig } from 'mysql'
 import { Dict, difference, makeArray, pick, Time } from 'cosmokit'
 import { Database, Driver, Eval, executeUpdate, Field, isEvalExpr, Model, RuntimeError, Selection } from '@minatojs/core'
-import { Builder, escapeId } from '@minatojs/sql-utils'
+import { Builder, escapeId, transformRandom } from '@minatojs/sql-utils'
 import Logger from 'reggol'
 
 declare module 'mysql' {
@@ -305,6 +305,7 @@ export class MySQLDriver extends Driver {
 
   query<T = any>(sql: string): Promise<T> {
     const error = new Error()
+    sql = transformRandom(sql, 'RAND()')
     return new Promise((resolve, reject) => {
       this.pool.query(sql, (err: Error, results) => {
         if (!err) return resolve(results)

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -1,6 +1,6 @@
 import { deepEqual, Dict, difference, isNullable, makeArray, union } from 'cosmokit'
 import { Database, Driver, Eval, executeUpdate, Field, Model, Selection } from '@minatojs/core'
-import { Builder, escapeId } from '@minatojs/sql-utils'
+import { Builder, escapeId, transformRandom } from '@minatojs/sql-utils'
 import { promises as fs } from 'fs'
 import init from '@minatojs/sql.js'
 import Logger from 'reggol'
@@ -233,6 +233,7 @@ export class SQLiteDriver extends Driver {
 
   #exec(sql: string, params: any, callback: (stmt: init.Statement) => any) {
     try {
+      sql = sql = transformRandom(sql, 'RANDOM()')
       const stmt = this.db.prepare(sql)
       const result = callback(stmt)
       stmt.free()


### PR DESCRIPTION
https://github.com/shigma/minato/issues/20

支持了SQLite和MySQL，可以使用`.orderBy(() => $.random())`来让数据库随机排序了。不接受参数。

core里的`Eval.*** = `部分不是很理解，是在memory里用的？不确定是不是这么写

mongo不太熟，不会改...