### PR TITLE
feat(mongo): optimize set, upsert operations

### DIFF
--- a/packages/core/src/eval.ts
+++ b/packages/core/src/eval.ts
@@ -5,12 +5,6 @@ export function isEvalExpr(value: any): value is Eval.Expr {
   return value && Object.keys(value).some(key => key.startsWith('$'))
 }
 
-export function hasEvalExpr(value: any, exprKeys?: ('' | keyof Eval.Static)[]): boolean {
-  return value && typeof value === 'object' && Object.keys(value).some(key =>
-    (key.startsWith('$') && (!exprKeys?.length || exprKeys.includes(key.slice(1) as any)))
-    || hasEvalExpr(value[key], exprKeys))
-}
-
 type $Date = Date
 type $RegExp = RegExp
 

--- a/packages/core/src/eval.ts
+++ b/packages/core/src/eval.ts
@@ -5,6 +5,12 @@ export function isEvalExpr(value: any): value is Eval.Expr {
   return value && Object.keys(value).some(key => key.startsWith('$'))
 }
 
+export function hasEvalExpr(value: any, exprKeys?: ('' | keyof Eval.Static)[]): boolean {
+  return value && typeof value === 'object' && Object.keys(value).some(key =>
+    (key.startsWith('$') && (!exprKeys?.length || exprKeys.includes(key.slice(1) as any)))
+    || hasEvalExpr(value[key], exprKeys))
+}
+
 type $Date = Date
 type $RegExp = RegExp
 

--- a/packages/mongo/src/index.ts
+++ b/packages/mongo/src/index.ts
@@ -495,8 +495,7 @@ export class MongoDriver extends Driver {
       for (const update of data) {
         const query = this.transformQuery(pick(update, keys), table)
         const transformer = new Transformer(this.getVirtualKey(table), undefined, '$' + tempKey + '.')
-        const $set = this.unpatchVirtual(table, Object.fromEntries(Object.entries(update)
-          .map(([key, value]) => [key, transformer.eval(value)])))
+        const $set = transformer.eval(update)
         const $unset = Object.entries($set)
           .filter(([_, value]) => typeof value === 'object')
           .map(([key, _]) => key)

--- a/packages/mongo/src/index.ts
+++ b/packages/mongo/src/index.ts
@@ -382,7 +382,7 @@ export class MongoDriver extends Driver {
   }
 
   async set(sel: Selection.Mutable, update: {}) {
-    const { query, table, ref } = sel
+    const { query, table } = sel
     const filter = this.transformQuery(query, table)
     if (!filter) return
     const coll = this.db.collection(table)

--- a/packages/mongo/src/utils.ts
+++ b/packages/mongo/src/utils.ts
@@ -76,8 +76,11 @@ const aggrKeys = ['$sum', '$avg', '$min', '$max', '$count']
 
 export class Transformer {
   private counter = 0
+  public walkedKeys: string[]
 
-  constructor(public virtualKey?: string, public lookup?: boolean) {}
+  constructor(public virtualKey?: string, public lookup?: boolean, public recursivePrefix: string = '$') {
+    this.walkedKeys = []
+  }
 
   public createKey() {
     return '_temp_' + ++this.counter
@@ -90,11 +93,14 @@ export class Transformer {
   private transformEvalExpr(expr: any, group?: Dict) {
     if (expr.$) {
       if (typeof expr.$ === 'string') {
-        return '$' + this.getActualKey(expr.$)
+        this.walkedKeys.push(this.getActualKey(expr.$))
+        return this.recursivePrefix + this.getActualKey(expr.$)
       } else if (this.lookup) {
-        return '$' + expr.$[0] + '.' + this.getActualKey(expr.$[1])
+        this.walkedKeys.push(expr.$[0] + '.' + this.getActualKey(expr.$[1]))
+        return this.recursivePrefix + expr.$[0] + '.' + this.getActualKey(expr.$[1])
       } else {
-        return '$' + this.getActualKey(expr.$[1])
+        this.walkedKeys.push(this.getActualKey(expr.$[1]))
+        return this.recursivePrefix + this.getActualKey(expr.$[1])
       }
     }
 
@@ -117,14 +123,15 @@ export class Transformer {
     }
 
     if (typeof expr === 'string') {
-      return '$' + expr
+      this.walkedKeys.push(expr)
+      return this.recursivePrefix + expr
     }
 
     return this.transformEvalExpr(expr)
   }
 
   public eval(expr: any, group?: Dict) {
-    if (typeof expr === 'number' || typeof expr === 'string' || typeof expr === 'boolean') {
+    if (isNullable(expr) || typeof expr === 'number' || typeof expr === 'string' || typeof expr === 'boolean') {
       return expr
     }
 
@@ -238,24 +245,5 @@ export class Transformer {
       }
       stages.push({ $project })
     }
-  }
-}
-
-export function * parseUnusedFields(initialModel: any, updateModel: any, prefix: string = '') {
-  for (const key in initialModel){
-    const initialKey = prefix + key, newPrefix = initialKey + '.'
-    // Already hit, reject initial
-    if (initialKey in updateModel) continue
-
-    // Search for partial results
-    const newUpdateEntries = Object.entries(updateModel).filter(([k, m]) => k.startsWith(newPrefix))
-
-    // No overlapping, accept initial
-    if (!newUpdateEntries.length) {
-      yield [initialKey, initialModel[key]]
-      continue
-    }
-    const nextUpdateModel = Object.fromEntries(newUpdateEntries)
-    yield * parseUnusedFields(initialModel[key], nextUpdateModel, newPrefix)
   }
 }

--- a/packages/mongo/src/utils.ts
+++ b/packages/mongo/src/utils.ts
@@ -240,3 +240,22 @@ export class Transformer {
     }
   }
 }
+
+export function * parseUnusedFields(initialModel: any, updateModel: any, prefix: string = '') {
+  for (const key in initialModel){
+    const initialKey = prefix + key, newPrefix = initialKey + '.'
+    // Already hit, reject initial
+    if (initialKey in updateModel) continue
+
+    // Search for partial results
+    const newUpdateEntries = Object.entries(updateModel).filter(([k, m]) => k.startsWith(newPrefix))
+
+    // No overlapping, accept initial
+    if (!newUpdateEntries.length) {
+      yield [initialKey, initialModel[key]]
+      continue
+    }
+    const nextUpdateModel = Object.fromEntries(newUpdateEntries)
+    yield * parseUnusedFields(initialModel[key], nextUpdateModel, newPrefix)
+  }
+}

--- a/packages/mongo/src/utils.ts
+++ b/packages/mongo/src/utils.ts
@@ -118,7 +118,7 @@ export class Transformer {
   }
 
   private transformAggr(expr: any) {
-    if (typeof expr === 'number' || typeof expr === 'boolean') {
+    if (typeof expr === 'number' || typeof expr === 'boolean' || expr instanceof Date) {
       return expr
     }
 
@@ -131,7 +131,7 @@ export class Transformer {
   }
 
   public eval(expr: any, group?: Dict) {
-    if (isNullable(expr) || typeof expr === 'number' || typeof expr === 'string' || typeof expr === 'boolean') {
+    if (isComparable(expr) || isNullable(expr)) {
       return expr
     }
 


### PR DESCRIPTION
Currently, `set` and `update` operations require looking up all involved documents before actual operations, which we aim at removing the phase.

There are concepts that may hurt performance of mongodb from design:
-	Auto-increment primary key
-	Initial field value
-	EvalExpresssions in update operations

To ensure autoInc, every insertion must be count before submitting, therefore we can only optimize situations disabling autoInc.

Initial values must be present when inserting a new document. Due to mongodb restriction on single update operation, fields must be disjoint, therefore we need to calculate the difference from initial value to insert value. Mongodb's dotted notton are required to specify nesting fields.

Mongodb from 4.2 support aggregation pipelines in update operators, therefore transforming expressions to native aggregation may be possible. 

## Task list

- [x] optimize when no evalExprs

- [x] transform evalExprs to aggregation pipeline