### PR TITLE
feat(mongo): support migrate virtualKey

### DIFF
--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -111,7 +111,7 @@ export class Model<S = any> {
 
     this.primary = primary || this.primary
     this.autoInc = autoInc || this.autoInc
-    this.unique.push(...unique)
+    unique.forEach(key => this.unique.includes(key) || this.unique.push(key))
     Object.assign(this.foreign, foreign)
 
     if (callback) this.migrations.set(callback, Object.keys(fields))


### PR DESCRIPTION
Support auto migrating optimizeIndex setting in prepare().
Store table preference in _fields.virtual, cause i don't want to create another meta table.
Support crash consistency, cause this migration can cost minutes for large database.

Also: fix Model.extend when Model::unique will grow everytime plugin-database reload.
(which cause _createIndexes to create duplicate Indexes)

PS. No test available cause I just don't know how and where to create tests for this specific case. Multi threading fails my attempts everytime.