### PR TITLE
feat(minato): support subquery, fix koishijs/koishi#595

### DIFF
--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -115,7 +115,9 @@ export class Database<S = any> {
     this.extend(name, fields, { callback })
   }
 
-  select<T extends Keys<S>>(table: T, query?: Query<S[T]>): Selection<S[T]> {
+  select<T>(table: Selection<T>, query?: Query<T>): Selection<T>
+  select<T extends Keys<S>>(table: T, query?: Query<S[T]>): Selection<S[T]>
+  select(table: any, query?: any) {
     return new Selection(this.getDriver(table), table, query)
   }
 
@@ -128,14 +130,14 @@ export class Database<S = any> {
         sel.args[0].having = Eval.and(query(...tables.map(name => sel.row[name])))
       }
       sel.args[0].optional = Object.fromEntries(tables.map((name, index) => [name, optional?.[index]]))
-      return new Selection(this.getDriver(sel), sel)
+      return this.select(sel)
     } else {
       const sel = new Selection(this.getDriver(Object.values(tables)[0]), valueMap(tables, (t: TableLike<S>) => typeof t === 'string' ? this.select(t) : t))
       if (typeof query === 'function') {
         sel.args[0].having = Eval.and(query(sel.row))
       }
       sel.args[0].optional = optional
-      return new Selection(this.getDriver(sel), sel)
+      return this.select(sel)
     }
   }
 

--- a/packages/core/src/eval.ts
+++ b/packages/core/src/eval.ts
@@ -243,6 +243,9 @@ Eval.object = (fields) => {
 Eval.array = unary('array', (expr, table) => Array.isArray(table)
   ? table.map(data => executeAggr(expr, data))
   : Array.from(executeEval(table, expr)))
+
+Eval.exec = unary('exec', (expr, data) => (expr.driver as any).executeSelection(expr, data))
+
 export { Eval as $ }
 
 type MapUneval<S> = {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -123,18 +123,18 @@ function executeFieldQuery(query: Query.FieldQuery, data: any) {
   return true
 }
 
-export function executeQuery(data: any, query: Query.Expr, ref: string): boolean {
+export function executeQuery(data: any, query: Query.Expr, ref: string, env: any = {}): boolean {
   const entries: [string, any][] = Object.entries(query)
   return entries.every(([key, value]) => {
     // execute logical query
     if (key === '$and') {
-      return (value as Query.Expr[]).reduce((prev, query) => prev && executeQuery(data, query, ref), true)
+      return (value as Query.Expr[]).reduce((prev, query) => prev && executeQuery(data, query, ref, env), true)
     } else if (key === '$or') {
-      return (value as Query.Expr[]).reduce((prev, query) => prev || executeQuery(data, query, ref), false)
+      return (value as Query.Expr[]).reduce((prev, query) => prev || executeQuery(data, query, ref, env), false)
     } else if (key === '$not') {
-      return !executeQuery(data, value, ref)
+      return !executeQuery(data, value, ref, env)
     } else if (key === '$expr') {
-      return executeEval({ [ref]: data, _: data }, value)
+      return executeEval({ ...env, [ref]: data, _: data }, value)
     }
 
     // execute field query

--- a/packages/mongo/src/utils.ts
+++ b/packages/mongo/src/utils.ts
@@ -1,6 +1,7 @@
 import { Dict, isNullable, valueMap } from 'cosmokit'
 import { Eval, isComparable, Query, Selection } from '@minatojs/core'
 import { Filter, FilterOperators } from 'mongodb'
+import MongoDriver from '.'
 
 function createFieldFilter(query: Query.FieldQuery, key: string) {
   const filters: Filter<any>[] = []
@@ -82,10 +83,18 @@ const aggrKeys = ['$sum', '$avg', '$min', '$max', '$count', '$length', '$array']
 
 export class Transformer {
   private counter = 0
-  private evalOperators: EvalOperators
-  public walkedKeys: string[]
+  public table!: string
+  public walkedKeys: string[] = []
+  public pipeline: any[] = []
+  protected lookups: any[] = []
+  public evalKey?: string
+  private refTables: string[] = []
+  private refVirtualKeys: Dict<string> = {}
+  public aggrDefault: any
 
-  constructor(public virtualKey?: string, public lookup?: boolean, public recursivePrefix: string = '$') {
+  private evalOperators: EvalOperators
+
+  constructor(private tables: string[], public virtualKey?: string, public recursivePrefix: string = '$') {
     this.walkedKeys = []
 
     this.evalOperators = {
@@ -93,12 +102,13 @@ export class Transformer {
         if (typeof arg === 'string') {
           this.walkedKeys.push(this.getActualKey(arg))
           return this.recursivePrefix + this.getActualKey(arg)
-        } else if (this.lookup) {
-          this.walkedKeys.push(arg[0] + '.' + this.getActualKey(arg[1]))
-          return this.recursivePrefix + arg[0] + '.' + this.getActualKey(arg[1])
-        } else {
+        } else if (this.tables.includes(arg[0])) {
           this.walkedKeys.push(this.getActualKey(arg[1]))
           return this.recursivePrefix + this.getActualKey(arg[1])
+        } else if (this.refTables.includes(arg[0])) {
+          return `$$${arg[0]}.` + this.getActualKey(arg[1], arg[0])
+        } else {
+          throw new Error(`$ not transformed: ${JSON.stringify(arg)}`)
         }
       },
       $if: (arg, group) => ({ $cond: arg.map(val => this.eval(val, group)) }),
@@ -131,6 +141,45 @@ export class Transformer {
           }, 0],
         }
       },
+
+      $exec: (arg, group) => {
+        const sel = arg as Selection
+        const transformer = this.createSubquery(sel)
+        if (!transformer) throw new Error(`Selection cannot be executed: ${JSON.stringify(arg)}`)
+
+        const name = this.createKey()
+        this.lookups.push({
+          $lookup: {
+            from: transformer.table,
+            as: name,
+            let: {
+              [this.tables[0]]: '$$ROOT',
+            },
+            pipeline: transformer.pipeline,
+          },
+        }, {
+          $set: {
+            [name]: !(sel.args[0] as any).$ ? {
+              $getField: {
+                input: {
+                  $ifNull: [
+                    { $arrayElemAt: ['$' + name, 0] },
+                    { [transformer.evalKey!]: transformer.aggrDefault },
+                  ],
+                },
+                field: transformer.evalKey!,
+              },
+            } : {
+              $map: {
+                input: '$' + name,
+                as: 'el',
+                in: '$$el.' + transformer.evalKey!,
+              },
+            },
+          },
+        })
+        return `$${name}`
+      },
     }
   }
 
@@ -138,8 +187,8 @@ export class Transformer {
     return '_temp_' + ++this.counter
   }
 
-  protected getActualKey(key: string) {
-    return key === this.virtualKey ? '_id' : key
+  protected getActualKey(key: string, ref?: string) {
+    return key === (ref ? this.refVirtualKeys[ref] : this.virtualKey) ? '_id' : key
   }
 
   private transformEvalExpr(expr: any, group?: Dict) {
@@ -153,6 +202,10 @@ export class Transformer {
       if (this.evalOperators[key]) {
         return this.evalOperators[key](expr[key], group)
       }
+    }
+
+    if (Array.isArray(expr)) {
+      return expr.map(val => this.eval(val, group))
     }
 
     return valueMap(expr as any, (value) => {
@@ -177,6 +230,12 @@ export class Transformer {
     return this.transformEvalExpr(expr)
   }
 
+  public flushLookups() {
+    const ret = this.lookups
+    this.lookups = []
+    return ret
+  }
+
   public eval(expr: any, group?: Dict) {
     if (isComparable(expr) || isNullable(expr)) {
       return expr
@@ -187,6 +246,7 @@ export class Transformer {
         if (!expr[type]) continue
         const key = this.createKey()
         const value = this.transformAggr(expr[type])
+        this.aggrDefault = 0
         if (type === '$count') {
           group![key] = { $addToSet: value }
           return { $size: '$' + key }
@@ -194,6 +254,7 @@ export class Transformer {
           group![key] = { $push: value }
           return { $size: '$' + key }
         } else if (type === '$array') {
+          this.aggrDefault = []
           group![key] = { $push: value }
           return '$' + key
         } else {
@@ -274,7 +335,7 @@ export class Transformer {
     if (group) {
       const $group: Dict = { _id: {} }
       const $project: Dict = { _id: 0 }
-      stages.push({ $group })
+      const groupStages: any[] = [{ $group }]
 
       for (const key in fields) {
         if (group.includes(key)) {
@@ -286,14 +347,14 @@ export class Transformer {
       }
       if (having['$and'].length) {
         const $expr = this.eval(having, $group)
-        stages.push({ $match: { $expr } })
+        groupStages.push(...this.flushLookups(), { $match: { $expr } })
       }
-      stages.push({ $project })
+      stages.push(...this.flushLookups(), ...groupStages, { $project })
       $group['_id'] = model.parse($group['_id'], false)
     } else if (fields) {
       const $project = valueMap(fields, (expr) => this.eval(expr))
       $project._id = 0
-      stages.push({ $project })
+      stages.push(...this.flushLookups(), { $project })
     } else {
       const $project: Dict = { _id: 0 }
       for (const key in model.fields) {
@@ -301,5 +362,73 @@ export class Transformer {
       }
       stages.push({ $project })
     }
+  }
+
+  protected createSubquery(sel: Selection.Immutable) {
+    const predecessor = new Transformer(Object.keys(sel.tables))
+    predecessor.refTables = [...this.refTables, ...this.tables]
+    predecessor.refVirtualKeys = this.refVirtualKeys
+    return predecessor.select(sel)
+  }
+
+  public select(sel: Selection.Immutable) {
+    const { table, query } = sel
+    if (typeof table === 'string') {
+      this.table = table
+      this.refVirtualKeys[sel.ref] = this.virtualKey = (sel.driver as MongoDriver).getVirtualKey(table)!
+    } else if (table instanceof Selection) {
+      const predecessor = this.createSubquery(table)
+      if (!predecessor) return
+      this.table = predecessor.table
+      this.pipeline.push(...predecessor.flushLookups(), ...predecessor.pipeline)
+    } else {
+      for (const [name, subtable] of Object.entries(table)) {
+        const predecessor = this.createSubquery(subtable)
+        if (!predecessor) return
+        if (!this.table) {
+          this.table = predecessor.table
+          this.pipeline.push(...predecessor.flushLookups(), ...predecessor.pipeline, {
+            $replaceRoot: { newRoot: { [name]: '$$ROOT' } },
+          })
+          continue
+        }
+        const $lookup = {
+          from: predecessor.table,
+          as: name,
+          pipeline: predecessor.pipeline,
+        }
+        const $unwind = {
+          path: `$${name}`,
+        }
+        this.pipeline.push({ $lookup }, { $unwind })
+      }
+      if (sel.args[0].having['$and'].length) {
+        const $expr = this.eval(sel.args[0].having)
+        this.pipeline.push(...this.flushLookups(), { $match: { $expr } })
+      }
+    }
+
+    // where
+    const filter = this.query(query)
+    if (!filter) return
+    if (Object.keys(filter).length) {
+      this.pipeline.push(...this.flushLookups(), { $match: filter })
+    }
+
+    if (sel.type === 'get') {
+      this.modifier(this.pipeline, sel)
+    } else if (sel.type === 'eval') {
+      const $ = this.createKey()
+      const $group: Dict = { _id: null }
+      const $project: Dict = { _id: 0 }
+      $project[$] = this.eval(sel.args[0], $group)
+      if (Object.keys($group).length === 1) {
+        this.pipeline.push(...this.flushLookups(), { $project })
+      } else {
+        this.pipeline.push({ $group }, ...this.flushLookups(), { $project })
+      }
+      this.evalKey = $
+    }
+    return this
   }
 }

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -1,7 +1,7 @@
 import { createPool, format } from '@vlasky/mysql'
 import type { OkPacket, Pool, PoolConfig, PoolConnection } from 'mysql'
 import { Dict, difference, makeArray, pick, Time } from 'cosmokit'
-import { Database, Driver, Eval, executeUpdate, Field, isEvalExpr, Model, RuntimeError, Selection } from '@minatojs/core'
+import { Database, Driver, Eval, executeUpdate, Field, isEvalExpr, Model, randomId, RuntimeError, Selection } from '@minatojs/core'
 import { Builder, escapeId, isBracketed } from '@minatojs/sql-utils'
 import Logger from 'reggol'
 
@@ -114,6 +114,8 @@ class MySQLBuilder extends Builder {
     '\\': '\\\\',
   }
 
+  prequeries: string[] = []
+
   constructor(tables?: Dict<Model>, private compat: Compat = {}) {
     super(tables)
 
@@ -174,11 +176,37 @@ class MySQLBuilder extends Builder {
   }
 
   protected groupArray(value: string) {
-    if (!this.compat.maria105) return super.groupArray(value)
+    if (!this.compat.maria) return super.groupArray(value)
     const res = this.state.sqlType === 'json' ? `concat('[', group_concat(${value}), ']')`
       : `concat('[', group_concat(json_extract(json_object('v', ${value}), '$.v')), ']')`
     this.state.sqlType = 'json'
     return `ifnull(${res}, json_array())`
+  }
+
+  protected parseSelection(sel: Selection) {
+    if (!this.compat.maria && !this.compat.mysql57) return super.parseSelection(sel)
+    const { args: [expr], ref, table, tables } = sel
+    const restore = this.saveState({ wrappedSubquery: true, tables })
+    const inner = this.get(table as Selection, true, true) as string
+    const output = this.parseEval(expr, false)
+    const refFields = this.state.refFields
+    restore()
+    let query: string
+    if (!(sel.args[0] as any).$) {
+      query = `(SELECT ${output} AS value FROM ${inner} ${isBracketed(inner) ? ref : ''})`
+    } else {
+      query = `(ifnull((SELECT ${this.groupArray(output)} AS value FROM ${inner} ${isBracketed(inner) ? ref : ''}), json_array()))`
+    }
+    if (Object.keys(refFields ?? {}).length) {
+      const funcname = `minato_tfunc_${randomId()}`
+      const decls = Object.values(refFields ?? {}).map(x => `${x} JSON`).join(',')
+      const args = Object.keys(refFields ?? {}).map(x => this.state.refFields?.[x] ?? x).map(x => this.jsonQuote(x, true)).join(',')
+      query = this.state.sqlType === 'json' ? `ifnull(${query}, json_array())` : this.jsonQuote(query)
+      this.prequeries.push(`DROP FUNCTION IF EXISTS ${funcname}`)
+      this.prequeries.push(`CREATE FUNCTION ${funcname} (${decls}) RETURNS JSON DETERMINISTIC RETURN ${query}`)
+      this.state.sqlType = 'json'
+      return `${funcname}(${args})`
+    } else return query
   }
 
   toUpdateExpr(item: any, key: string, field?: Field, upsert?: boolean) {
@@ -526,8 +554,8 @@ INSERT INTO mtt VALUES(json_extract(j, concat('$[', i, ']'))); SET i=i+1; END WH
     const builder = new MySQLBuilder(tables, this._compat)
     const sql = builder.get(sel)
     if (!sql) return []
-    return this.queue(sql).then((data) => {
-      return data.map((row) => builder.load(model, row))
+    return Promise.all([...builder.prequeries, sql].map(x => this.queue(x))).then((data) => {
+      return data.at(-1).map((row) => builder.load(model, row))
     })
   }
 
@@ -536,8 +564,10 @@ INSERT INTO mtt VALUES(json_extract(j, concat('$[', i, ']'))); SET i=i+1; END WH
     const inner = builder.get(sel.table as Selection, true, true)
     const output = builder.parseEval(expr, false)
     const ref = isBracketed(inner) ? sel.ref : ''
-    const [data] = await this.queue(`SELECT ${output} AS value FROM ${inner} ${ref}`)
-    return builder.load(data.value)
+    const sql = `SELECT ${output} AS value FROM ${inner} ${ref}`
+    return Promise.all([...builder.prequeries, sql].map(x => this.queue(x))).then((data) => {
+      return builder.load(data.at(-1)[0].value)
+    })
   }
 
   async set(sel: Selection.Mutable, data: {}) {

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -364,6 +364,19 @@ class PostgresBuilder extends Builder {
     return `coalesce(jsonb_agg(${value}), '[]'::jsonb)`
   }
 
+  protected parseSelection(sel: Selection) {
+    const { args: [expr], ref, table, tables } = sel
+    const restore = this.saveState({ tables })
+    const inner = this.get(table as Selection, true, true) as string
+    const output = this.parseEval(expr, false)
+    restore()
+    if (!(sel.args[0] as any).$) {
+      return `(SELECT ${output} AS value FROM ${inner} ${isBracketed(inner) ? ref : ''})`
+    } else {
+      return `(coalesce((SELECT ${this.groupArray(output)} AS value FROM ${inner} ${isBracketed(inner) ? ref : ''}), '[]'::jsonb))`
+    }
+  }
+
   escapeId = escapeId
 
   escapeKey(value: string) {

--- a/packages/sql-utils/src/index.ts
+++ b/packages/sql-utils/src/index.ts
@@ -32,6 +32,9 @@ interface State {
   sqlTypes?: Dict<SQLType>
   group?: boolean
   tables?: Dict<Model>
+  refFields?: Dict<string>
+  refTables?: Dict<Model>
+  wrappedSubquery?: boolean
 }
 
 export class Builder {
@@ -173,6 +176,8 @@ export class Builder {
 
       $object: (fields) => this.groupObject(fields),
       $array: (expr) => this.groupArray(this.parseEval(expr, false)),
+
+      $exec: (sel) => this.parseSelection(sel as Selection),
     }
   }
 
@@ -233,6 +238,19 @@ export class Builder {
 
   protected logicalNot(condition: string) {
     return `NOT(${condition})`
+  }
+
+  protected parseSelection(sel: Selection) {
+    const { args: [expr], ref, table, tables } = sel
+    const restore = this.saveState({ tables })
+    const inner = this.get(table as Selection, true, true) as string
+    const output = this.parseEval(expr, false)
+    restore()
+    if (!(sel.args[0] as any).$) {
+      return `(SELECT ${output} AS value FROM ${inner} ${isBracketed(inner) ? ref : ''})`
+    } else {
+      return `(ifnull((SELECT ${this.groupArray(output)} AS value FROM ${inner} ${isBracketed(inner) ? ref : ''}), json_array()))`
+    }
   }
 
   protected jsonLength(value: string) {
@@ -385,6 +403,20 @@ export class Builder {
     // the only table must be the main table
     || (Object.keys(this.state.tables).length === 1 && table in this.state.tables) ? '' : `${this.escapeId(table)}.`)
 
+    // field from outer selection
+    if (!(table in (this.state.tables || {})) && (table in (this.state.refTables || {}))) {
+      const fields = this.state.refTables?.[table]?.fields || {}
+      const res = (fields[key]?.expr) ? this.parseEvalExpr(fields[key]?.expr)
+        : this.transformKey(key, fields, `${this.escapeId(table)}.`, `${table}.${key}`)
+      if (this.state.wrappedSubquery) {
+        if (res in (this.state.refFields ?? {})) return this.state.refFields![res]
+        const key = `minato_tvar_${randomId()}`
+        ;(this.state.refFields ??= {})[res] = key
+        this.state.sqlType = 'json'
+        return this.escapeId(key)
+      } else return res
+    }
+
     return this.transformKey(key, fields, prefix, `${table}.${key}`)
   }
 
@@ -394,6 +426,15 @@ export class Builder {
       return this.escape(expr)
     }
     return unquote ? this.jsonUnquote(this.parseEvalExpr(expr)) : this.parseEvalExpr(expr)
+  }
+
+  protected saveState(extra: Partial<State> = {}) {
+    const thisState = this.state
+    this.state = { refTables: { ...(this.state.refTables || {}), ...(this.state.tables || {}) }, ...extra }
+    return () => {
+      thisState.sqlType = this.state.sqlType
+      this.state = thisState
+    }
   }
 
   suffix(modifier: Modifier) {
@@ -433,13 +474,12 @@ export class Builder {
     } else {
       const sqlTypes: Dict<SQLType> = {}
       const joins: string[] = Object.entries(table).map(([key, table]) => {
-        const thisState = this.state
-        this.state = { tables: table.tables }
+        const restore = this.saveState({ tables: table.tables })
         const t = `${this.get(table, true, false, false)} AS ${this.escapeId(key)}`
         for (const [fieldKey, fieldType] of Object.entries(this.state.sqlTypes!)) {
           sqlTypes[`${key}.${fieldKey}`] = fieldType
         }
-        this.state = thisState
+        restore()
         return t
       })
       this.state.sqlTypes = sqlTypes

--- a/packages/tests/src/query.ts
+++ b/packages/tests/src/query.ts
@@ -163,6 +163,10 @@ namespace QueryOperators {
         value: { $in: [3, 4, 5] },
       })).eventually.to.have.length(2)
 
+      await expect(database.get('temp1', (row) => {
+        return $.in(row.value, [3, 4, 5])
+      })).eventually.to.have.length(2)
+
       await expect(database.get('temp1', {
         value: { $nin: [4, 5, 6] },
       })).eventually.to.have.length(2)

--- a/packages/tests/src/selection.ts
+++ b/packages/tests/src/selection.ts
@@ -172,6 +172,7 @@ namespace SelectionTests {
     it('shorthand', async () => {
       await expect(database.eval('foo', row => $.sum(row.id))).to.eventually.equal(6)
       await expect(database.eval('foo', row => $.count(row.value))).to.eventually.equal(2)
+      await expect(database.eval('foo', row => $.count(row.value), { id: -1 })).to.eventually.equal(0)
     })
 
     it('inner expressions', async () => {
@@ -332,6 +333,199 @@ namespace SelectionTests {
         .join(['foo', 'bar'] as const)
         .execute(row => $.count(row.bar.id))
       ).to.eventually.equal(6)
+    })
+  }
+
+  export function subquery(database: Database<Tables>) {
+    it('select', async () => {
+      await expect(database.select('foo')
+        .project({
+          x: r1 => database
+            .select('foo', r2 => $.gt(r1.id, r2.id))
+            .evaluate(r2 => $.count(r2.id)),
+        })
+        .orderBy('x')
+        .execute()).to.eventually.deep.equal([
+          { x: 0 },
+          { x: 1 },
+          { x: 2 },
+        ])
+    })
+
+    it('where', async () => {
+      await expect(database.get('foo', row => $.in(
+        row.id, database.select('foo').project({ x: row => $.add(row.id, 1) }).evaluate('x')
+      ))).to.eventually.deep.equal([
+        { id: 2, value: 2 },
+        { id: 3, value: 2 },
+      ])
+    })
+
+    it('from', async () => {
+      const sel = database.select('foo').project({
+        x: row => $.add(row.id, row.value),
+        id: 'id'
+      })
+      await expect(database.select(sel).execute(row => $.sum(row.x))).to.eventually.equal(10)
+    })
+
+    it('select join', async () => {
+      await expect(database.select('foo')
+        .project({
+          x: r => database.select('bar')
+            .where(row => $.and($.gte(row.pid, r.id), $.lt(row.uid, r.id)))
+            .evaluate(row => $.count(row.id)),
+        })
+        .execute())
+        .to.eventually.deep.equal([
+          { x: 0 },
+          { x: 2 },
+          { x: 1 },
+        ])
+    })
+
+    it('groupBy', async () => {
+      const sel = database.select('bar').evaluate(row => $.count(row.id))
+      await expect(database
+        .select('foo')
+        .groupBy({
+          key: row => $.subtract(sel, row.value),
+        })
+        .orderBy('key')
+        .execute()
+      ).to.eventually.deep.equal([
+        { key: 4 },
+        { key: 6 },
+      ])
+    })
+
+    it('having', async () => {
+      const sel = database.select('bar').evaluate(row => $.subtract($.count(row.id), 5))
+      await expect(database
+        .select('foo')
+        .having(row => $.gt($.sum(row.id), sel))
+        .groupBy('value')
+        .execute()
+      ).to.eventually.deep.equal([
+        { value: 2 },
+      ])
+    })
+
+    it('nested subquery', async () => {
+      const one = database.select('bar').evaluate(row => $.subtract($.count(row.id), 5))
+      const sel = x => database.select('bar').evaluate(row => $.add(one, $.subtract($.count(row.id), x), 0))
+      await expect(database
+        .select('foo')
+        .project({
+          t: row => row.id,
+          x: row => sel(row.id),
+        })
+        .execute()
+      ).to.eventually.deep.equal([
+        { t: 1, x: 6 },
+        { t: 2, x: 5 },
+        { t: 3, x: 4 },
+      ])
+    })
+
+    it('inner join', async () => {
+      const one = database.select('bar').evaluate(row => $.subtract($.count(row.id), 5))
+      const sel = x => database.select('bar').where(row => $.eq(x, row.uid)).evaluate(row => $.count(row.id))
+      await expect(database
+        .join(['foo', 'bar'] as const, (foo, bar) => $.gt(foo.value, one))
+        .execute()
+      ).to.eventually.have.length(12)
+
+      await expect(database
+        .join(['foo', 'bar'] as const, (foo, bar) => $.lt(foo.value, sel(foo.id)))
+        .execute()
+      ).to.eventually.have.length(6)
+    })
+
+    it('join selection', async () => {
+      await expect(database
+        .select(
+          database.select('foo'),
+        )
+        .execute()
+      ).to.eventually.have.length(3)
+
+      await expect(database
+        .join({
+          foo1: database.select('foo'),
+          foo2: database.select('foo'),
+        })
+        .execute()
+      ).to.eventually.have.length(9)
+    })
+
+    it('return array', async () => {
+      await expect(database.select('foo')
+        .project({
+          x: r => database.select('bar')
+            .where(row => $.and($.gte(row.pid, r.id), $.lt(row.uid, r.id)))
+            .evaluate('id'),
+        })
+        .execute())
+        .to.eventually.deep.equal([
+          { x: [] },
+          { x: [3, 4] },
+          { x: [4] },
+        ])
+    })
+
+    it('return nested array', async () => {
+      await expect(database.select('foo')
+        .project({
+          x: r => database.select('bar')
+            .where(row => $.and($.gte(row.pid, r.id), $.lt(row.uid, r.id)))
+            .project({
+              id: _ => database.select('foo').project({
+                id: row => $.add(row.id, r.id),
+              }).evaluate('id'),
+            })
+            .evaluate('id')
+        })
+        .execute())
+        .to.eventually.deep.equal([
+          { x: [] },
+          { x: [[3, 4, 5], [3, 4, 5]] },
+          { x: [[4, 5, 6]] },
+        ])
+
+      await expect(database.select('foo')
+        .project({
+          x: r => database.select('bar')
+            .where(row => $.and($.gte(row.pid, r.id), $.lt(row.uid, r.id)))
+            .project({
+              id: _ => database.select('foo').project({
+                id: row => $.add(row.id, r.id),
+              }).evaluate('id'),
+            })
+            .evaluate('id')
+        })
+        .execute(row => $.array(row.x)))
+        .to.eventually.deep.equal([
+          [],
+          [[3, 4, 5], [3, 4, 5]],
+          [[4, 5, 6]],
+        ])
+    })
+
+    it('return array of objects', async () => {
+      await expect(database.select('foo')
+        .project({
+          x: r => database.select('bar')
+            .where(row => $.and($.gte(row.pid, r.id), $.lt(row.uid, r.id)))
+            .evaluate(),
+        })
+        .orderBy(row => $.length(row.x))
+        .execute())
+        .to.eventually.have.shape([
+          { x: [] },
+          { x: [{ id: 4 }] },
+          { x: [{ id: 3 }, { id: 4 }] },
+        ])
     })
   }
 }


### PR DESCRIPTION
This pr is rebased to first-class json type.

ref: koishijs/koishi#595

## Features
- `Selection<S>.evaluate<T>(callback: Callback<S, T>): Expr<T>`

convert the selection into subquery using ther aggregation callback in type of `Expr<T>`, therefore it can be used in any place a `Expr<T>` can fill.

Eg. 

	assert((await database.select('bar').execute(row => $.count(row.id))) === 6)
	const one = database.select('bar').evaluate(row => $.subtract($.count(row.id), 5))
	// We can replace all constant integers inside expressions using one
	// ...

- `Selection<S>.evaluate<K extends Keys<S>>(field: K): Expr<S[K][]>`

Pick the specific field of the selection and aggregate all rows into array

Eg.

	database.select('foo')
	  .project({
	    x: r => database.select('bar').where(row => $.lt(row.uid, r.id)).evaluate('id')
	  })
	.execute()
	// Get id list and store into single field

- `Selection<S>.evaluate(): Expr<S[]>`
shortcut for `Selection.evaluate(row => $.array($.object(row)))`

Check tests for more usage

## Changes

- Refactor mongo's `eval()` to make all pipeline processed at server side
- Use procedures to bypass the field accessing limitation in inner derived tables
- Refactor memory driver

## Tasks

- [x] mongo
- [x] mysql8.0/sqlite
- [x] mysql5.7/mariadb
- [x] memory
- [x] non-aggr subquery return list
- [x] more test for nested subqueries
