### PR TITLE
fix(mongo,postgres): create/upsert autoInc field with primary set

### DIFF
--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -393,10 +393,17 @@ export class PostgresDriver extends Driver<PostgresDriver.Config> {
     const { table, model } = sel
     const builder = new PostgresBuilder(sel.tables)
     const formatted = builder.dump(model, data)
+
     const keys = Object.keys(formatted)
     const [row] = await this.query([
       `INSERT INTO ${builder.escapeId(table)} (${keys.map(builder.escapeId).join(', ')})`,
-      `VALUES (${keys.map(key => builder.escape(formatted[key])).join(', ')})`,
+      `VALUES (${keys.map(key => {
+        if (model.autoInc && key === model.primary) {
+          return `(select ${formatted[key]} from (select setval(pg_get_serial_sequence(${builder.escapeKey(table)}, ${builder.escapeKey(key)}),
+          greatest(nextval(pg_get_serial_sequence(${builder.escapeKey(table)}, ${builder.escapeKey(key)}))-1, ${formatted[key]}))))`
+        }
+        return builder.escape(formatted[key])
+      }).join(', ')})`,
       `RETURNING *`,
     ].join(' '))
     return builder.load(model, row)
@@ -436,11 +443,17 @@ export class PostgresDriver extends Driver<PostgresDriver.Config> {
     const formatValues = (table: string, data: object, keys: readonly string[]) => {
       return keys.map((key) => {
         const field = this.database.tables[table]?.fields[key]
-        if (model.autoInc && model.primary === key && !data[key]) return 'default'
+        // if (model.autoInc && model.primary === key && !data[key]) return 'default'
+
+        if (model.autoInc && model.primary === key) {
+          return data[key] ? `(select ${data[key]} from (select setval(pg_get_serial_sequence(${builder.escapeKey(table)}, ${builder.escapeKey(key)}),
+            greatest(nextval(pg_get_serial_sequence(${builder.escapeKey(table)}, ${builder.escapeKey(key)}))-1, ${data[key]}))))`
+            : 'default'
+        }
         return builder.escape(data[key], field)
       }).join(', ')
     }
-
+    // console.log(updateFields, dataFields)
     const update = updateFields.map((field) => {
       const escaped = builder.escapeId(field)
       const branches: Dict<any[]> = {}

--- a/packages/tests/src/update.ts
+++ b/packages/tests/src/update.ts
@@ -272,6 +272,15 @@ namespace OrmOperations {
         { ida: 12, idb: 'c', value: 'd' },
       ], ['value'] as any)).to.eventually.have.shape({ inserted: 2, matched: 1 })
     })
+
+    it('set primary with autoInc', async () => {
+      await setup(database, 'temp2', barTable)
+      await expect(database.upsert('temp2', [
+        { id: 100, text: '100' },
+        { text: 'new row' },
+      ])).to.eventually.have.shape({ inserted: 2, matched: 0 })
+      await expect(database.get('temp2', {})).to.eventually.have.length(barTable.length + 2)
+    })
   }
 
   export const remove = function Remove(database: Database<Tables>) {

--- a/packages/tests/src/update.ts
+++ b/packages/tests/src/update.ts
@@ -272,15 +272,6 @@ namespace OrmOperations {
         { ida: 12, idb: 'c', value: 'd' },
       ], ['value'] as any)).to.eventually.have.shape({ inserted: 2, matched: 1 })
     })
-
-    it('set primary with autoInc', async () => {
-      await setup(database, 'temp2', barTable)
-      await expect(database.upsert('temp2', [
-        { id: 100, text: '100' },
-        { text: 'new row' },
-      ])).to.eventually.have.shape({ inserted: 2, matched: 0 })
-      await expect(database.get('temp2', {})).to.eventually.have.length(barTable.length + 2)
-    })
   }
 
   export const remove = function Remove(database: Database<Tables>) {


### PR DESCRIPTION
Consider the following snippets with autoInc enabled:
```
await database.create('foo', { id: 1 })
await database.create('foo', { num: 1 })
```


Currently in mongo driver, `create({ id: 1})` will not update autoInc field, thus the second `create({ num: 1 })` will get the same `id=1`, causing duplicate primary error.

PostgreSQL's serial type acts exactly our mongo's way. It only update itself when triggering default. The PR gives a workaround but i have no idea whether there exists better solution.

Unit tests are missing in the PR because there are not proper file to write them. (current update.ts will not run into problem cuz the autoInc is already high enough in that case) We should write them in model.ts later the other PR is merged.